### PR TITLE
Add necessary setup.py file to make project installable and add missing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,8 @@
+from setuptools import find_packages, setup
+
+setup(
+    name="zim_anything",
+    version="1.0",
+    install_requires=[],
+    packages=find_packages(),
+)


### PR DESCRIPTION
Add necessary setup.py file to make project installable and add missing `__init__.py` file for modeling directory.  
Package name will be zim_anything to avoid confusion with any existing zim python package.  
But you still import files using `import zim`. 
You should consider renaming zim directory to zim_anything and adapt documentation and demo code

Package can be installed using `pip install .` or `python setup.py install`(these way is deprecated)
